### PR TITLE
Feat: 코디 기록 CRUD API 구현

### DIFF
--- a/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
+++ b/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
@@ -57,6 +57,9 @@ public class Clothes {
         this.isFavorite = !this.isFavorite;
     }
 
+    public void increaseWearingCount() {
+        this.wearCount++;
+    }
 
     public void updateInfo(String name, String category, String personalColor, String color,
                            Boolean suitableForRain, List<String> situationKeywords) {

--- a/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
+++ b/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
@@ -61,6 +61,12 @@ public class Clothes {
         this.wearCount++;
     }
 
+    public void decreaseWearingCount() {
+        if (this.wearCount > 0) {
+            this.wearCount--;
+        }
+    }
+
     public void updateInfo(String name, String category, String personalColor, String color,
                            Boolean suitableForRain, List<String> situationKeywords) {
         this.name = name;

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -2,22 +2,24 @@ package com.example.codionbe.domain.coordination.controller;
 
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
+import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Tag(name = "코디 기록", description = "코디 기록 관련 API")
 public interface CoordinationApi {
 
-    @Operation(summary = "코디 등록 API")
+    @Operation(summary = "코디 등록 API", description = "선택한 날짜의 코디를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "코디 등록 성공")
     @PostMapping("")
     ResponseEntity<SuccessResponse<Void>> createCoordination(
@@ -29,5 +31,12 @@ public interface CoordinationApi {
     @PatchMapping
     ResponseEntity<SuccessResponse<Void>> updateCoordination(
             @RequestBody CoordinationUpdateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "코디 상세 조회 API", description = "날짜를 기준으로 코디 상세 정보를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "코디 상세 조회 성공")
+    @GetMapping
+    ResponseEntity<SuccessResponse<CoordinationDetailResponse>> getCoordination(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.coordination.controller;
 
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -20,5 +22,12 @@ public interface CoordinationApi {
     @PostMapping("")
     ResponseEntity<SuccessResponse<Void>> createCoordination(
             @RequestBody CreateCoordinationRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "코디 수정 API", description = "선택한 날짜의 코디 정보를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "코디 수정 성공")
+    @PatchMapping
+    ResponseEntity<SuccessResponse<Void>> updateCoordination(
+            @RequestBody CoordinationUpdateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -21,7 +21,7 @@ public interface CoordinationApi {
 
     @Operation(summary = "코디 등록 API", description = "선택한 날짜의 코디를 등록합니다.")
     @ApiResponse(responseCode = "200", description = "코디 등록 성공")
-    @PostMapping("")
+    @PostMapping
     ResponseEntity<SuccessResponse<Void>> createCoordination(
             @RequestBody CreateCoordinationRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
@@ -39,4 +39,12 @@ public interface CoordinationApi {
     ResponseEntity<SuccessResponse<CoordinationDetailResponse>> getCoordination(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "코디 삭제 API", description = "해당 날짜의 코디를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "코디 삭제 성공")
+    @DeleteMapping
+    ResponseEntity<SuccessResponse<Void>> deleteCoordination(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -1,0 +1,24 @@
+package com.example.codionbe.domain.coordination.controller;
+
+import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "코디 기록", description = "코디 기록 관련 API")
+public interface CoordinationApi {
+
+    @Operation(summary = "코디 등록 API")
+    @ApiResponse(responseCode = "200", description = "코디 등록 성공")
+    @PostMapping("")
+    ResponseEntity<SuccessResponse<Void>> createCoordination(
+            @RequestBody CreateCoordinationRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -2,6 +2,7 @@ package com.example.codionbe.domain.coordination.controller;
 
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
+import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.domain.coordination.exception.CoordinationSuccessCode;
 import com.example.codionbe.domain.coordination.service.CoordinationService;
 import com.example.codionbe.global.auth.CustomUserDetails;
@@ -11,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +38,13 @@ public class CoordinationController implements CoordinationApi {
 
         coordinationService.updateCoordination(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_UPDATE_SUCCESS, null));
+    }
+
+    @Override
+    public ResponseEntity<SuccessResponse<CoordinationDetailResponse>> getCoordination(
+            LocalDate date, CustomUserDetails userDetails) {
+
+        CoordinationDetailResponse response = coordinationService.getCoordination(userDetails.getUser().getId(), date);
+        return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_GET_SUCCESS, response));
     }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.coordination.controller;
 
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.exception.CoordinationSuccessCode;
 import com.example.codionbe.domain.coordination.service.CoordinationService;
 import com.example.codionbe.global.auth.CustomUserDetails;
@@ -25,5 +26,14 @@ public class CoordinationController implements CoordinationApi {
 
         coordinationService.createCoordination(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_CREATE_SUCCESS, null));
+    }
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> updateCoordination(
+            CoordinationUpdateRequest request,
+            CustomUserDetails userDetails) {
+
+        coordinationService.updateCoordination(userDetails.getUser().getId(), request);
+        return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_UPDATE_SUCCESS, null));
     }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -47,4 +47,13 @@ public class CoordinationController implements CoordinationApi {
         CoordinationDetailResponse response = coordinationService.getCoordination(userDetails.getUser().getId(), date);
         return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_GET_SUCCESS, response));
     }
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> deleteCoordination(
+            LocalDate date, CustomUserDetails userDetails) {
+
+        coordinationService.deleteCoordination(userDetails.getUser().getId(), date);
+        return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_DELETE_SUCCESS, null));
+    }
+
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -1,0 +1,29 @@
+package com.example.codionbe.domain.coordination.controller;
+
+import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.exception.CoordinationSuccessCode;
+import com.example.codionbe.domain.coordination.service.CoordinationService;
+import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/coordination")
+public class CoordinationController implements CoordinationApi {
+
+    private final CoordinationService coordinationService;
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> createCoordination(
+            CreateCoordinationRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        coordinationService.createCoordination(userDetails.getUser().getId(), request);
+        return ResponseEntity.ok(new SuccessResponse<>(CoordinationSuccessCode.COORDINATION_CREATE_SUCCESS, null));
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/CreateCoordinationRequest.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/CreateCoordinationRequest.java
@@ -1,0 +1,12 @@
+package com.example.codionbe.domain.coordination.dto;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+public class CreateCoordinationRequest {
+    private LocalDate date;
+    private List<Long> clothesIds;
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/request/CoordinationUpdateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/request/CoordinationUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.example.codionbe.domain.coordination.dto.request;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+public class CoordinationUpdateRequest {
+    private LocalDate date;
+    private List<Long> clothesIds;
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/response/ClothesSimpleResponse.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/response/ClothesSimpleResponse.java
@@ -1,0 +1,17 @@
+package com.example.codionbe.domain.coordination.dto.response;
+
+import com.example.codionbe.domain.closet.entity.Clothes;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ClothesSimpleResponse {
+    private Long id;
+    private String name;
+    private String imageUrl;
+
+    public static ClothesSimpleResponse from(Clothes clothes) {
+        return new ClothesSimpleResponse(clothes.getId(), clothes.getName(), clothes.getImageUrl());
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
@@ -1,0 +1,15 @@
+package com.example.codionbe.domain.coordination.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CoordinationDetailResponse {
+    private Long coordinationId;
+    private LocalDate date;
+    private List<ClothesSimpleResponse> clothes;
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/entity/Coordination.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/entity/Coordination.java
@@ -1,0 +1,43 @@
+package com.example.codionbe.domain.coordination.entity;
+
+import com.example.codionbe.domain.closet.entity.Clothes;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Coordination {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private LocalDate date;
+
+    private boolean isDeleted = false;
+
+    @ManyToMany
+    @JoinTable(
+            name = "coordination_clothes",
+            joinColumns = @JoinColumn(name = "coordination_id"),
+            inverseJoinColumns = @JoinColumn(name = "clothes_id")
+    )
+    private List<Clothes> clothesList;
+
+    public void updateClothes(List<Clothes> newClothesList) {
+        this.clothesList.clear();
+        this.clothesList.addAll(newClothesList);
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CoordinationErrorCode implements ErrorCode {
-    INVALID_CLOTHES(HttpStatus.BAD_REQUEST, "COORD_001", "유효하지 않은 옷 정보입니다.");
+    INVALID_CLOTHES(HttpStatus.BAD_REQUEST, "COORD_001", "유효하지 않은 옷 정보입니다."),
+    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COORD_002", "해당 날짜의 코디를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
@@ -1,0 +1,16 @@
+package com.example.codionbe.domain.coordination.exception;
+
+import com.example.codionbe.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CoordinationErrorCode implements ErrorCode {
+    INVALID_CLOTHES(HttpStatus.BAD_REQUEST, "COORD_001", "유효하지 않은 옷 정보입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CoordinationSuccessCode implements SuccessCode {
     COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다."),
-    COORDINATION_UPDATE_SUCCESS(HttpStatus.OK, "COORD_002", "코디 수정에 성공했습니다.");
+    COORDINATION_UPDATE_SUCCESS(HttpStatus.OK, "COORD_002", "코디 수정에 성공했습니다."),
+    COORDINATION_GET_SUCCESS(HttpStatus.OK, "COORD_005", "코디 상세 조회에 성공했습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CoordinationSuccessCode implements SuccessCode {
-    COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다.");
+    COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다."),
+    COORDINATION_UPDATE_SUCCESS(HttpStatus.OK, "COORD_002", "코디 수정에 성공했습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CoordinationSuccessCode implements SuccessCode {
     COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다."),
     COORDINATION_UPDATE_SUCCESS(HttpStatus.OK, "COORD_002", "코디 수정에 성공했습니다."),
-    COORDINATION_GET_SUCCESS(HttpStatus.OK, "COORD_005", "코디 상세 조회에 성공했습니다.");
+    COORDINATION_GET_SUCCESS(HttpStatus.OK, "COORD_005", "코디 상세 조회에 성공했습니다."),
+    COORDINATION_DELETE_SUCCESS(HttpStatus.OK, "COORD_006", "코디 삭제에 성공했습니다.");
 
 
 

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
@@ -1,0 +1,16 @@
+package com.example.codionbe.domain.coordination.exception;
+
+import com.example.codionbe.global.common.success.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CoordinationSuccessCode implements SuccessCode {
+    COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/repository/CoordinationRepository.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/repository/CoordinationRepository.java
@@ -1,0 +1,22 @@
+package com.example.codionbe.domain.coordination.repository;
+
+import com.example.codionbe.domain.coordination.entity.Coordination;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CoordinationRepository extends JpaRepository<Coordination, Long> {
+
+    // 유저의 코디 전체 조회
+    List<Coordination> findAllByUserIdAndIsDeletedFalseOrderByDateDesc(Long userId);
+
+    // 날짜 기준으로 코디 1개 찾기 (수정, 삭제, 상세조회용)
+    Optional<Coordination> findByUserIdAndDateAndIsDeletedFalse(Long userId, LocalDate date);
+
+    // 특정 코디 ID로 존재 여부 확인 (예: 상세조회, 삭제, 수정 등)
+    Optional<Coordination> findByIdAndIsDeletedFalse(Long coordinationId);
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -4,6 +4,8 @@ import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.repository.ClothesRepository;
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
+import com.example.codionbe.domain.coordination.dto.response.ClothesSimpleResponse;
+import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.domain.coordination.entity.Coordination;
 import com.example.codionbe.domain.coordination.exception.CoordinationErrorCode;
 import com.example.codionbe.domain.coordination.repository.CoordinationRepository;
@@ -12,7 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -63,4 +67,20 @@ public class CoordinationService {
         coordination.updateClothes(newClothes);
     }
 
+    @Transactional(readOnly = true)
+    public CoordinationDetailResponse getCoordination(Long userId, LocalDate date) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, date)
+                .orElseThrow(() -> new CustomException(CoordinationErrorCode.COORDINATION_NOT_FOUND));
+
+        List<ClothesSimpleResponse> clothesResponses = coordination.getClothesList().stream()
+                .map(ClothesSimpleResponse::from)
+                .collect(Collectors.toList());
+
+        return new CoordinationDetailResponse(
+                coordination.getId(),
+                coordination.getDate(),
+                clothesResponses
+        );
+    }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -83,4 +83,17 @@ public class CoordinationService {
                 clothesResponses
         );
     }
+
+    @Transactional
+    public void deleteCoordination(Long userId, LocalDate date) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, date)
+                .orElseThrow(() -> new CustomException(CoordinationErrorCode.COORDINATION_NOT_FOUND));
+
+        // 연관 옷들 착용 횟수 감소
+        coordination.getClothesList().forEach(Clothes::decreaseWearingCount);
+
+        // soft delete
+        coordination.delete();
+    }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -1,0 +1,36 @@
+package com.example.codionbe.domain.coordination.service;
+
+import com.example.codionbe.domain.closet.entity.Clothes;
+import com.example.codionbe.domain.closet.repository.ClothesRepository;
+import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.entity.Coordination;
+import com.example.codionbe.domain.coordination.repository.CoordinationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CoordinationService {
+
+    private final CoordinationRepository coordinationRepository;
+    private final ClothesRepository clothesRepository;
+
+    @Transactional
+    public void createCoordination(Long userId, CreateCoordinationRequest request) {
+        List<Clothes> clothesList = clothesRepository.findAllById(request.getClothesIds());
+
+        // 착용 횟수 증가
+        clothesList.forEach(Clothes::increaseWearingCount);
+
+        Coordination coordination = Coordination.builder()
+                .userId(userId)
+                .date(request.getDate())
+                .clothesList(clothesList)
+                .build();
+
+        coordinationRepository.save(coordination);
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -3,8 +3,11 @@ package com.example.codionbe.domain.coordination.service;
 import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.repository.ClothesRepository;
 import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.entity.Coordination;
+import com.example.codionbe.domain.coordination.exception.CoordinationErrorCode;
 import com.example.codionbe.domain.coordination.repository.CoordinationRepository;
+import com.example.codionbe.global.common.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,4 +36,31 @@ public class CoordinationService {
 
         coordinationRepository.save(coordination);
     }
+
+    @Transactional
+    public void updateCoordination(Long userId, CoordinationUpdateRequest request) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, request.getDate())
+                .orElseThrow(() -> new CustomException(CoordinationErrorCode.COORDINATION_NOT_FOUND));
+
+        // 기존 옷 착용 횟수 감소
+        coordination.getClothesList().forEach(Clothes::decreaseWearingCount);
+
+        // 새 옷 ID들 조회
+        List<Clothes> newClothes = clothesRepository.findAllById(request.getClothesIds());
+
+        // 삭제되었거나 권한 없는 옷 체크
+        for (Clothes clothes : newClothes) {
+            if (clothes.isDeleted() || !clothes.getUserId().equals(userId)) {
+                throw new CustomException(CoordinationErrorCode.INVALID_CLOTHES);
+            }
+        }
+
+        // 새 옷 착용 횟수 증가
+        newClothes.forEach(Clothes::increaseWearingCount);
+
+        // 옷 교체
+        coordination.updateClothes(newClothes);
+    }
+
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #36 

## 🔑 Key Changes

1. 내용
    - 사용자의 착장 기록을 위한 코디 기록(Coordination) 기능을 구현했습니다.
    - 등록, 수정, 조회, 삭제가 가능한 CRUD API입니다.
    - 1. 코디 기록 등록 (POST /coordination)
    - 2. 코디 기록 수정 (PATCH /coordination?date=yyyy-MM-dd)
    - 3. 코디 기록 상세 조회 (GET /coordination?date=yyyy-MM-dd)
    - 4. 코디 기록 삭제  (DELETE /coordination?date=yyyy-MM-dd)

## 📸 Screenshot
