### PR TITLE
Feat: 코디 기록 코멘트 API 구현

### DIFF
--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -1,0 +1,25 @@
+package com.example.codionbe.domain.comment.controller;
+
+import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "코디 기록 코멘트", description = "코디 기록 코멘트 관련 API")
+public interface CommentApi {
+
+    @Operation(summary = "코멘트 생성 API", description = "코디에 코멘트를 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "코멘트 등록 성공")
+    @PostMapping
+    ResponseEntity<SuccessResponse<Void>> createComment(
+            @RequestBody CommentCreateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+}

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -8,11 +8,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @Tag(name = "코디 기록 코멘트", description = "코디 기록 코멘트 관련 API")
 public interface CommentApi {
@@ -29,6 +30,13 @@ public interface CommentApi {
     @PatchMapping
     ResponseEntity<SuccessResponse<Void>> updateComment(
             @RequestBody CommentUpdateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "코멘트 삭제 API", description = "코디에 등록된 코멘트를 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "코멘트 삭제 성공")
+    @DeleteMapping
+    ResponseEntity<SuccessResponse<Void>> deleteComment(
+            @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
 }

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.comment.controller;
 
 import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -20,6 +22,13 @@ public interface CommentApi {
     @PostMapping
     ResponseEntity<SuccessResponse<Void>> createComment(
             @RequestBody CommentCreateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "코멘트 수정 API", description = "등록된 코멘트를 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "코멘트 수정 성공")
+    @PatchMapping
+    ResponseEntity<SuccessResponse<Void>> updateComment(
+            @RequestBody CommentUpdateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
 }

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -1,6 +1,6 @@
 package com.example.codionbe.domain.comment.controller;
 
-import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentCreateRequest;
 import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.success.SuccessResponse;

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
@@ -1,0 +1,29 @@
+package com.example.codionbe.domain.comment.controller;
+
+import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.exception.CommentSuccessCode;
+import com.example.codionbe.domain.comment.service.CommentService;
+import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/coordination/comment")
+public class CommentController implements CommentApi{
+
+    private final CommentService commentService;
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> createComment(
+            CommentCreateRequest request,
+            CustomUserDetails userDetails) {
+
+        commentService.createComment(userDetails.getUser().getId(), request);
+        return ResponseEntity.ok(new SuccessResponse<>(CommentSuccessCode.COMMENT_CREATE_SUCCESS, null));
+    }
+
+}

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
@@ -1,6 +1,6 @@
 package com.example.codionbe.domain.comment.controller;
 
-import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentCreateRequest;
 import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.domain.comment.exception.CommentSuccessCode;
 import com.example.codionbe.domain.comment.service.CommentService;

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
@@ -11,6 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/coordination/comment")
@@ -34,6 +36,14 @@ public class CommentController implements CommentApi{
 
         commentService.updateComment(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(new SuccessResponse<>(CommentSuccessCode.COMMENT_UPDATE_SUCCESS, null));
+    }
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> deleteComment(
+            LocalDate date, CustomUserDetails userDetails) {
+
+        commentService.deleteComment(userDetails.getUser().getId(), date);
+        return ResponseEntity.ok(new SuccessResponse<>(CommentSuccessCode.COMMENT_DELETE_SUCCESS, null));
     }
 
 }

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.comment.controller;
 
 import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.domain.comment.exception.CommentSuccessCode;
 import com.example.codionbe.domain.comment.service.CommentService;
 import com.example.codionbe.global.auth.CustomUserDetails;
@@ -24,6 +25,15 @@ public class CommentController implements CommentApi{
 
         commentService.createComment(userDetails.getUser().getId(), request);
         return ResponseEntity.ok(new SuccessResponse<>(CommentSuccessCode.COMMENT_CREATE_SUCCESS, null));
+    }
+
+    @Override
+    public ResponseEntity<SuccessResponse<Void>> updateComment(
+            CommentUpdateRequest request,
+            CustomUserDetails userDetails) {
+
+        commentService.updateComment(userDetails.getUser().getId(), request);
+        return ResponseEntity.ok(new SuccessResponse<>(CommentSuccessCode.COMMENT_UPDATE_SUCCESS, null));
     }
 
 }

--- a/src/main/java/com/example/codionbe/domain/comment/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/CommentCreateRequest.java
@@ -1,0 +1,12 @@
+package com.example.codionbe.domain.comment.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CommentCreateRequest {
+    private LocalDate date;
+    private String mood;     // "좋음", "보통", "나쁨"
+    private String content;  // 상세 코멘트
+}

--- a/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,4 +1,4 @@
-package com.example.codionbe.domain.comment.dto;
+package com.example.codionbe.domain.comment.dto.request;
 
 import lombok.Getter;
 

--- a/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.example.codionbe.domain.comment.dto.request;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CommentUpdateRequest {
+    private LocalDate date;
+    private String mood;
+    private String content;
+}

--- a/src/main/java/com/example/codionbe/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,16 @@
+package com.example.codionbe.domain.comment.dto.response;
+
+import com.example.codionbe.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentResponse {
+    private String mood;
+    private String content;
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(comment.getMood(), comment.getContent());
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/codionbe/domain/comment/entity/Comment.java
@@ -1,0 +1,25 @@
+package com.example.codionbe.domain.comment.entity;
+
+import com.example.codionbe.domain.coordination.entity.Coordination;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String mood; // "좋음", "보통", "나쁨"
+    private String content;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coordination_id")
+    private Coordination coordination;
+}
+

--- a/src/main/java/com/example/codionbe/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/codionbe/domain/comment/entity/Comment.java
@@ -21,5 +21,10 @@ public class Comment {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "coordination_id")
     private Coordination coordination;
+
+    public void update(String mood, String content) {
+        this.mood = mood;
+        this.content = content;
+    }
 }
 

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
@@ -1,0 +1,17 @@
+package com.example.codionbe.domain.comment.exception;
+
+import com.example.codionbe.global.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+
+    COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT_002", "이미 코멘트가 등록되어 있습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode {
 
-    COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT_002", "이미 코멘트가 등록되어 있습니다.");
+    COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT_002", "이미 코멘트가 등록되어 있습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "해당 코멘트가 존재하지 않습니다."),
+    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_002", "해당 날짜의 코디가 존재하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentSuccessCode implements SuccessCode {
 
-    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_001", "코멘트 등록에 성공했습니다.");
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_001", "코멘트 등록에 성공했습니다."),
+    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_002", "코멘트 수정에 성공했습니다.");
+
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
@@ -1,0 +1,18 @@
+package com.example.codionbe.domain.comment.exception;
+
+import com.example.codionbe.global.common.success.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommentSuccessCode implements SuccessCode {
+
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_001", "코멘트 등록에 성공했습니다.");
+
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CommentSuccessCode implements SuccessCode {
 
     COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_001", "코멘트 등록에 성공했습니다."),
-    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_002", "코멘트 수정에 성공했습니다.");
+    COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "COMMENT_002", "코멘트 수정에 성공했습니다."),
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_003", "코멘트 삭제에 성공했습니다.");
 
 
 

--- a/src/main/java/com/example/codionbe/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/example/codionbe/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.example.codionbe.domain.comment.repository;
+
+import com.example.codionbe.domain.comment.entity.Comment;
+import com.example.codionbe.domain.coordination.entity.Coordination;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Optional<Comment> findByCoordination(Coordination coordination);
+}

--- a/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @RequiredArgsConstructor
 public class CommentService {
@@ -49,4 +51,18 @@ public class CommentService {
 
         comment.update(request.getMood(), request.getContent());
     }
+
+    @Transactional
+    public void deleteComment(Long userId, LocalDate date) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, date)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COORDINATION_NOT_FOUND));
+
+        Comment comment = commentRepository.findByCoordination(coordination)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        commentRepository.delete(comment);
+        coordination.setComment(null); // 연관 관계도 끊어줌
+    }
+
 }

--- a/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
@@ -1,6 +1,6 @@
 package com.example.codionbe.domain.comment.service;
 
-import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentCreateRequest;
 import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.domain.comment.entity.Comment;
 import com.example.codionbe.domain.comment.exception.CommentErrorCode;

--- a/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
@@ -1,0 +1,40 @@
+package com.example.codionbe.domain.comment.service;
+
+import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.entity.Comment;
+import com.example.codionbe.domain.comment.exception.CommentErrorCode;
+import com.example.codionbe.domain.comment.repository.CommentRepository;
+import com.example.codionbe.domain.coordination.entity.Coordination;
+import com.example.codionbe.domain.coordination.exception.CoordinationErrorCode;
+import com.example.codionbe.domain.coordination.repository.CoordinationRepository;
+import com.example.codionbe.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CoordinationRepository coordinationRepository;
+    private final CommentRepository commentRepository;
+    @Transactional
+    public void createComment(Long userId, CommentCreateRequest request) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, request.getDate())
+                .orElseThrow(() -> new CustomException(CoordinationErrorCode.COORDINATION_NOT_FOUND));
+
+        if (coordination.getComment() != null) {
+            throw new CustomException(CommentErrorCode.COMMENT_ALREADY_EXISTS);
+        }
+
+        Comment comment = Comment.builder()
+                .mood(request.getMood())
+                .content(request.getContent())
+                .coordination(coordination)
+                .build();
+
+        coordination.setComment(comment); // 양방향 연관
+    }
+
+}

--- a/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
+++ b/src/main/java/com/example/codionbe/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.comment.service;
 
 import com.example.codionbe.domain.comment.dto.CommentCreateRequest;
+import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.domain.comment.entity.Comment;
 import com.example.codionbe.domain.comment.exception.CommentErrorCode;
 import com.example.codionbe.domain.comment.repository.CommentRepository;
@@ -37,4 +38,15 @@ public class CommentService {
         coordination.setComment(comment); // 양방향 연관
     }
 
+    @Transactional
+    public void updateComment(Long userId, CommentUpdateRequest request) {
+        Coordination coordination = coordinationRepository
+                .findByUserIdAndDateAndIsDeletedFalse(userId, request.getDate())
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COORDINATION_NOT_FOUND));
+
+        Comment comment = commentRepository.findByCoordination(coordination)
+                .orElseThrow(() -> new CustomException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+        comment.update(request.getMood(), request.getContent());
+    }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -1,6 +1,6 @@
 package com.example.codionbe.domain.coordination.controller;
 
-import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -1,6 +1,6 @@
 package com.example.codionbe.domain.coordination.controller;
 
-import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.domain.coordination.exception.CoordinationSuccessCode;

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/request/CreateCoordinationRequest.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/request/CreateCoordinationRequest.java
@@ -1,4 +1,4 @@
-package com.example.codionbe.domain.coordination.dto;
+package com.example.codionbe.domain.coordination.dto.request;
 
 import lombok.Data;
 

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
@@ -1,5 +1,6 @@
 package com.example.codionbe.domain.coordination.dto.response;
 
+import com.example.codionbe.domain.comment.dto.response.CommentResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,4 +13,5 @@ public class CoordinationDetailResponse {
     private Long coordinationId;
     private LocalDate date;
     private List<ClothesSimpleResponse> clothes;
+    private CommentResponse comment;
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/entity/Coordination.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/entity/Coordination.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.coordination.entity;
 
 import com.example.codionbe.domain.closet.entity.Clothes;
+import com.example.codionbe.domain.comment.entity.Comment;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -31,6 +32,14 @@ public class Coordination {
             inverseJoinColumns = @JoinColumn(name = "clothes_id")
     )
     private List<Clothes> clothesList;
+
+    @OneToOne(mappedBy = "coordination", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Comment comment;
+
+    public void setComment(Comment comment) {
+        this.comment = comment;
+    }
+
 
     public void updateClothes(List<Clothes> newClothesList) {
         this.clothesList.clear();

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -2,6 +2,7 @@ package com.example.codionbe.domain.coordination.service;
 
 import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.repository.ClothesRepository;
+import com.example.codionbe.domain.comment.dto.response.CommentResponse;
 import com.example.codionbe.domain.coordination.dto.request.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.dto.response.ClothesSimpleResponse;
@@ -77,10 +78,16 @@ public class CoordinationService {
                 .map(ClothesSimpleResponse::from)
                 .collect(Collectors.toList());
 
+        CommentResponse commentResponse = null;
+        if (coordination.getComment() != null) {
+            commentResponse = CommentResponse.from(coordination.getComment());
+        }
+
         return new CoordinationDetailResponse(
                 coordination.getId(),
                 coordination.getDate(),
-                clothesResponses
+                clothesResponses,
+                commentResponse
         );
     }
 

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -2,7 +2,7 @@ package com.example.codionbe.domain.coordination.service;
 
 import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.repository.ClothesRepository;
-import com.example.codionbe.domain.coordination.dto.CreateCoordinationRequest;
+import com.example.codionbe.domain.coordination.dto.request.CreateCoordinationRequest;
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.dto.response.ClothesSimpleResponse;
 import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #39 

## 🔑 Key Changes

1. 내용
    - 코디 기록에 대한 코멘트 기능을 구현했습니다.
    - 1. 코디 코멘트 등록 (POST /coordination/comment)
    - 2. 코디 코멘트 수정 (PATCH /coordination/comment?date=yyyy-MM-dd)
    - 3. 코디 코멘트 삭제 (DELETE /coordination/comment?date=yyyy-MM-dd)
    
    - 추가적으로 변경 사항은 코디 조회 시 코멘트 추가

## 📸 Screenshot
