### PR TITLE
Docs: Swagger API 응답 예시 실제 값으로 수정

### DIFF
--- a/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
+++ b/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
@@ -6,10 +6,15 @@ import com.example.codionbe.domain.closet.dto.request.UpdateClothesRequest;
 import com.example.codionbe.domain.closet.dto.response.ClothesResponse;
 import com.example.codionbe.domain.closet.dto.response.FavoriteToggleResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +27,18 @@ import java.util.List;
 
 @Tag(name = "MY 옷장", description = "MY 옷장 관련 API")
 public interface ClosetApi {
-    @Operation(summary = "옷 등록 API")
-    @ApiResponse(responseCode = "200", description = "옷 등록 성공")
+    @Operation(summary = "옷 등록 API", description = "새로운 옷의 정보를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "옷 등록 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_001",
+                              "message": "옷 등록에 성공했습니다.",
+                              "data": null
+                            }
+                            """)))
+    })
     @PostMapping(value = "/closet", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<SuccessResponse<Void>> registerClothes(
             @RequestPart("image") MultipartFile image,
@@ -31,8 +46,18 @@ public interface ClosetApi {
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     ) throws IOException;
 
-    @Operation(summary = "옷 전체 조회 API")
-    @ApiResponse(responseCode = "200", description = "MY 옷장 전체 조회 성공")
+    @Operation(summary = "옷 전체 조회 API", description = "전체 옷의 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "MY 옷장 목록 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_002",
+                              "message": "MY 옷장 목록 조회에 성공했습니다.",
+                              "data": [ ]
+                            }
+                            """)))
+    })
     @GetMapping("/closet")
     ResponseEntity<SuccessResponse<List<ClothesResponse>>> getClothesList(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -40,7 +65,33 @@ public interface ClosetApi {
     );
 
     @Operation(summary = "옷 수정 API", description = "기존 옷 정보를 수정합니다.")
-    @ApiResponse(responseCode = "200", description = "옷 수정 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "옷 수정 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_003",
+                              "message": "옷 수정에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "옷 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_101",
+                              "message": "해당 옷을 찾을 수 없습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_102",
+                              "message": "해당 옷에 대한 권한이 없습니다."
+                            }
+                            """)))
+    })
     @PatchMapping("/closet/{clothesId}")
     ResponseEntity<SuccessResponse<Void>> updateClothes(
             @PathVariable("clothesId") Long clothesId,
@@ -50,7 +101,17 @@ public interface ClosetApi {
     ) throws IOException;
 
     @Operation(summary = "옷 삭제 API", description = "해당 옷을 MY 옷장에서 삭제합니다.")
-    @ApiResponse(responseCode = "200", description = "옷 삭제 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "옷 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_004",
+                              "message": "옷 삭제에 성공했습니다.",
+                              "data": null
+                            }
+                            """)))
+    })
     @DeleteMapping("/closet/{clothesId}")
     ResponseEntity<SuccessResponse<Void>> deleteClothes(
             @PathVariable("clothesId") Long clothesId,
@@ -58,15 +119,49 @@ public interface ClosetApi {
     );
 
     @Operation(summary = "옷 상세 조회 API", description = "옷 ID를 통해 옷의 상세 정보를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "옷 상세 조회 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "옷 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_006",
+                              "message": "옷 상세 조회에 성공했습니다.",
+                              "data": {
+                                "clothesId": 1,
+                                "name": "화이트 셔츠",
+                                "imageUrl": "https://s3.amazonaws.com/bucket/image.jpg",
+                                "category": "TOP",
+                                "personalColor": "SUMMER",
+                                "color": "WHITE",
+                                "situationKeywords": ["데이트", "면접"],
+                                "wearCount": 0,
+                                "favorite": false,
+                                "wearableWhenRainy": true
+                              }
+                            }
+                            """)))
+    })
     @GetMapping("/closet/{clothesId}")
     ResponseEntity<SuccessResponse<ClothesResponse>> getClothesDetail(
             @PathVariable("clothesId") Long clothesId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
 
-    @Operation(summary = "즐겨찾기 토글 API", description = "옷의 즐겨찾기 상태를 반전시킵니다.")
-    @ApiResponse(responseCode = "200", description = "즐겨찾기 상태 변경 성공")
+    @Operation(summary = "즐겨찾기 토글 API", description = "옷의 즐겨찾기 상태를 바꿉니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "즐겨찾기 상태 변경 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "CLOSET_005",
+                              "message": "즐겨찾기 상태가 변경되었습니다.",
+                              "data": {
+                                "clothesId": 1,
+                                "favorite": true
+                              }
+                            }
+                            """)))
+    })
     @PatchMapping("/closet/{clothesId}/favorite")
     ResponseEntity<SuccessResponse<FavoriteToggleResponse>> toggleFavorite(
             @PathVariable("clothesId") Long clothesId,

--- a/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
+++ b/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
@@ -26,8 +26,10 @@ import java.io.IOException;
 import java.util.List;
 
 @Tag(name = "MY 옷장", description = "MY 옷장 관련 API")
+@RequestMapping("/closet")
 public interface ClosetApi {
-    @Operation(summary = "옷 등록 API", description = "새로운 옷의 정보를 등록합니다.")
+    @Operation(summary = "옷 등록 API", description = "새로운 옷의 정보를 등록합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)))
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "옷 등록 성공",
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
@@ -39,7 +41,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @PostMapping(value = "/closet", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<SuccessResponse<Void>> registerClothes(
             @RequestPart("image") MultipartFile image,
             @RequestPart("request") RegisterClothesRequest request,
@@ -58,7 +60,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @GetMapping("/closet")
+    @GetMapping
     ResponseEntity<SuccessResponse<List<ClothesResponse>>> getClothesList(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             ClothesFilterRequest filterRequest
@@ -92,7 +94,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @PatchMapping("/closet/{clothesId}")
+    @PatchMapping("/{clothesId}")
     ResponseEntity<SuccessResponse<Void>> updateClothes(
             @PathVariable("clothesId") Long clothesId,
             @RequestPart(value = "image", required = false) MultipartFile image,
@@ -112,7 +114,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @DeleteMapping("/closet/{clothesId}")
+    @DeleteMapping("/{clothesId}")
     ResponseEntity<SuccessResponse<Void>> deleteClothes(
             @PathVariable("clothesId") Long clothesId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
@@ -141,7 +143,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @GetMapping("/closet/{clothesId}")
+    @GetMapping("/{clothesId}")
     ResponseEntity<SuccessResponse<ClothesResponse>> getClothesDetail(
             @PathVariable("clothesId") Long clothesId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
@@ -162,7 +164,7 @@ public interface ClosetApi {
                             }
                             """)))
     })
-    @PatchMapping("/closet/{clothesId}/favorite")
+    @PatchMapping("/{clothesId}/favorite")
     ResponseEntity<SuccessResponse<FavoriteToggleResponse>> toggleFavorite(
             @PathVariable("clothesId") Long clothesId,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/ClothesFilterRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/ClothesFilterRequest.java
@@ -1,5 +1,6 @@
 package com.example.codionbe.domain.closet.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,11 +12,22 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "옷 필터 요청")
 public class ClothesFilterRequest {
-    private String personalColor;         // 예: 봄 웜
-    private String color;                 // 예: 갈색
-    private List<String> situationKeywords; // 예: 데이트, 캐주얼
-    private Boolean isFavorite;           // 즐겨찾기 여부
-//    private String perceivedTemperature;  // 체감온도 -> 예: 가을
-    private Boolean isWearableWhenRainy;  // 비 오는 날 가능 여부
+
+    @Schema(description = "퍼스널컬러", example = "봄 웜")
+    private String personalColor;
+
+    @Schema(description = "색상", example = "갈색")
+    private String color;
+
+    @Schema(description = "상황 키워드", example = "[\"데이트\", \"캐주얼\"]")
+    private List<String> situationKeywords;
+
+    @Schema(description = "즐겨찾기 여부", example = "true")
+    private Boolean isFavorite;
+
+    @Schema(description = "비 오는 날 착용 가능 여부", example = "false")
+    private Boolean isWearableWhenRainy;
 }
+

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/RegisterClothesRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/RegisterClothesRequest.java
@@ -1,16 +1,29 @@
 package com.example.codionbe.domain.closet.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
+@Schema(description = "옷 등록 요청")
 public class RegisterClothesRequest {
 
+    @Schema(description = "옷 이름", example = "화이트 셔츠")
     private String name;
+
+    @Schema(description = "카테고리", example = "TOP")
     private String category;
+
+    @Schema(description = "퍼스널컬러", example = "SUMMER")
     private String personalColor;
+
+    @Schema(description = "색상", example = "WHITE")
     private String color;
+
+    @Schema(description = "비 오는 날 착용 가능 여부", example = "true")
     private boolean suitableForRain;
+
+    @Schema(description = "상황 키워드", example = "[\"면접\", \"소개팅\"]")
     private List<String> situationKeywords;
 }

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/UpdateClothesRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/UpdateClothesRequest.java
@@ -1,5 +1,6 @@
 package com.example.codionbe.domain.closet.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -7,11 +8,24 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "옷 수정 요청")
 public class UpdateClothesRequest {
+
+    @Schema(description = "옷 이름", example = "린넨 셔츠")
     private String name;
+
+    @Schema(description = "카테고리", example = "TOP")
     private String category;
+
+    @Schema(description = "퍼스널컬러", example = "AUTUMN")
     private String personalColor;
+
+    @Schema(description = "색상", example = "BEIGE")
     private String color;
+
+    @Schema(description = "비 오는 날 착용 가능 여부", example = "false")
     private Boolean suitableForRain;
+
+    @Schema(description = "상황 키워드", example = "[\"데이트\", \"여행\"]")
     private List<String> situationKeywords;
 }

--- a/src/main/java/com/example/codionbe/domain/closet/dto/response/ClothesResponse.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/response/ClothesResponse.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.closet.dto.response;
 
 import com.example.codionbe.domain.closet.entity.Clothes;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,17 +10,37 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "옷 응답")
 public class ClothesResponse {
+
+    @Schema(description = "옷 ID", example = "1")
     private Long clothesId;
+
+    @Schema(description = "이름", example = "화이트 셔츠")
     private String name;
+
+    @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/bucket/image.jpg")
     private String imageUrl;
+
+    @Schema(description = "카테고리", example = "TOP")
     private String category;
+
+    @Schema(description = "퍼스널컬러", example = "SUMMER")
     private String personalColor;
+
+    @Schema(description = "색상", example = "WHITE")
     private String color;
+
+    @Schema(description = "상황 키워드", example = "[\"데이트\", \"면접\"]")
     private List<String> situationKeywords;
 //    private String perceivedTemperature;
+    @Schema(description = "비 오는 날 착용 가능 여부", example = "true")
     private boolean isWearableWhenRainy;
+
+    @Schema(description = "즐겨찾기 여부", example = "false")
     private boolean isFavorite;
+
+    @Schema(description = "착용 횟수", example = "3")
     private int wearCount;
 
     public static ClothesResponse from(Clothes c) {

--- a/src/main/java/com/example/codionbe/domain/closet/dto/response/FavoriteToggleResponse.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/response/FavoriteToggleResponse.java
@@ -1,11 +1,17 @@
 package com.example.codionbe.domain.closet.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "즐겨찾기 토글 응답")
 public class FavoriteToggleResponse {
+
+    @Schema(description = "옷 ID", example = "1")
     private Long clothesId;
+
+    @Schema(description = "즐겨찾기 여부", example = "true")
     private boolean isFavorite;
 }

--- a/src/main/java/com/example/codionbe/domain/closet/exception/ClosetErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/closet/exception/ClosetErrorCode.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ClosetErrorCode implements ErrorCode {
 
-    CLOTHES_NOT_FOUND(HttpStatus.NOT_FOUND, "CLOSET_001", "해당 옷을 찾을 수 없습니다."),
-    NO_AUTHORITY(HttpStatus.FORBIDDEN, "CLOSET_002", "해당 옷에 대한 권한이 없습니다.");
+    CLOTHES_NOT_FOUND(HttpStatus.NOT_FOUND, "CLOSET_101", "해당 옷을 찾을 수 없습니다."),
+    NO_AUTHORITY(HttpStatus.FORBIDDEN, "CLOSET_102", "해당 옷에 대한 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -3,10 +3,15 @@ package com.example.codionbe.domain.comment.controller;
 import com.example.codionbe.domain.comment.dto.request.CommentCreateRequest;
 import com.example.codionbe.domain.comment.dto.request.CommentUpdateRequest;
 import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -16,24 +21,87 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @Tag(name = "코디 기록 코멘트", description = "코디 기록 코멘트 관련 API")
+@RequestMapping("/coordination/comment")
 public interface CommentApi {
 
     @Operation(summary = "코멘트 생성 API", description = "코디에 코멘트를 등록합니다.")
-    @ApiResponse(responseCode = "200", description = "코멘트 등록 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코멘트 등록 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_001",
+                              "message": "코멘트 등록에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "400", description = "이미 코멘트가 존재함",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_102",
+                              "message": "이미 코멘트가 등록되어 있습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "코디 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_103",
+                              "message": "해당 날짜의 코디가 존재하지 않습니다."
+                            }
+                            """)))
+    })
     @PostMapping
     ResponseEntity<SuccessResponse<Void>> createComment(
             @RequestBody CommentCreateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "코멘트 수정 API", description = "등록된 코멘트를 수정합니다.")
-    @ApiResponse(responseCode = "200", description = "코멘트 수정 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코멘트 수정 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_002",
+                              "message": "코멘트 수정에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "코디 또는 코멘트 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_103",
+                              "message": "해당 날짜의 코디가 존재하지 않습니다."
+                            }
+                            """)))
+    })
     @PatchMapping
     ResponseEntity<SuccessResponse<Void>> updateComment(
             @RequestBody CommentUpdateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "코멘트 삭제 API", description = "코디에 등록된 코멘트를 삭제합니다.")
-    @ApiResponse(responseCode = "200", description = "코멘트 삭제 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코멘트 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_003",
+                              "message": "코멘트 삭제에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "코디 또는 코멘트 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COMMENT_103",
+                              "message": "해당 날짜의 코디가 존재하지 않습니다."
+                            }
+                            """)))
+    })
     @DeleteMapping
     ResponseEntity<SuccessResponse<Void>> deleteComment(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentController.java
@@ -8,14 +8,12 @@ import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/coordination/comment")
 public class CommentController implements CommentApi{
 
     private final CommentService commentService;

--- a/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,12 +1,22 @@
 package com.example.codionbe.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor
+@Schema(description = "코멘트 생성 요청")
 public class CommentCreateRequest {
+
+    @Schema(description = "코디 날짜", example = "2024-05-12")
     private LocalDate date;
-    private String mood;     // "좋음", "보통", "나쁨"
-    private String content;  // 상세 코멘트
+
+    @Schema(description = "기분 상태", example = "좋음") // "좋음", "보통", "나쁨"
+    private String mood;
+
+    @Schema(description = "코멘트 내용", example = "오늘 코디 정말 마음에 들어요!")
+    private String content;
 }

--- a/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,12 +1,22 @@
 package com.example.codionbe.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 
 @Getter
+@NoArgsConstructor
+@Schema(description = "코멘트 수정 요청")
 public class CommentUpdateRequest {
+
+    @Schema(description = "코디 날짜", example = "2024-05-12")
     private LocalDate date;
+
+    @Schema(description = "기분 상태", example = "보통")
     private String mood;
+
+    @Schema(description = "코멘트 내용", example = "기분은 평범하지만 날씨랑 잘 맞는 코디였어요.")
     private String content;
 }

--- a/src/main/java/com/example/codionbe/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/example/codionbe/domain/comment/dto/response/CommentResponse.java
@@ -1,13 +1,19 @@
 package com.example.codionbe.domain.comment.dto.response;
 
 import com.example.codionbe.domain.comment.entity.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "코멘트 응답")
 public class CommentResponse {
+
+    @Schema(description = "기분 상태", example = "좋음")
     private String mood;
+
+    @Schema(description = "코멘트 내용", example = "오늘 코디 정말 마음에 들어요!")
     private String content;
 
     public static CommentResponse from(Comment comment) {

--- a/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/comment/exception/CommentErrorCode.java
@@ -9,9 +9,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommentErrorCode implements ErrorCode {
 
-    COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT_002", "이미 코멘트가 등록되어 있습니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_001", "해당 코멘트가 존재하지 않습니다."),
-    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_002", "해당 날짜의 코디가 존재하지 않습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_101", "해당 코멘트가 존재하지 않습니다."),
+    COMMENT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "COMMENT_102", "이미 코멘트가 등록되어 있습니다."),
+    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_103", "해당 날짜의 코디가 존재하지 않습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -4,10 +4,15 @@ import com.example.codionbe.domain.coordination.dto.request.CreateCoordinationRe
 import com.example.codionbe.domain.coordination.dto.request.CoordinationUpdateRequest;
 import com.example.codionbe.domain.coordination.dto.response.CoordinationDetailResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -17,31 +22,101 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDate;
 
 @Tag(name = "코디 기록", description = "코디 기록 관련 API")
+@RequestMapping("/coordination")
 public interface CoordinationApi {
 
     @Operation(summary = "코디 등록 API", description = "선택한 날짜의 코디를 등록합니다.")
-    @ApiResponse(responseCode = "200", description = "코디 등록 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코디 등록 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_001",
+                              "message": "코디 등록에 성공했습니다.",
+                              "data": null
+                            }
+                            """)))
+    })
     @PostMapping
     ResponseEntity<SuccessResponse<Void>> createCoordination(
-            @RequestBody CreateCoordinationRequest request,
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "코디 등록 요청") CreateCoordinationRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "코디 수정 API", description = "선택한 날짜의 코디 정보를 수정합니다.")
-    @ApiResponse(responseCode = "200", description = "코디 수정 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코디 수정 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_002",
+                              "message": "코디 수정에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 옷 정보",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_101",
+                              "message": "유효하지 않은 옷 정보입니다."
+                            }
+                            """)))
+    })
     @PatchMapping
     ResponseEntity<SuccessResponse<Void>> updateCoordination(
-            @RequestBody CoordinationUpdateRequest request,
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "코디 수정 요청") CoordinationUpdateRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "코디 상세 조회 API", description = "날짜를 기준으로 코디 상세 정보를 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "코디 상세 조회 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코디 상세 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_003",
+                              "message": "코디 상세 조회에 성공했습니다.",
+                              "data": {
+                                "coordinationId": 1,
+                                "date": "2024-05-11",
+                                "clothes": [],
+                                "comment": null
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "코디를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_102",
+                              "message": "해당 날짜의 코디를 찾을 수 없습니다."
+                            }
+                            """)))
+    })
     @GetMapping
     ResponseEntity<SuccessResponse<CoordinationDetailResponse>> getCoordination(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
 
     @Operation(summary = "코디 삭제 API", description = "해당 날짜의 코디를 삭제합니다.")
-    @ApiResponse(responseCode = "200", description = "코디 삭제 성공")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코디 삭제 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_004",
+                              "message": "코디 삭제에 성공했습니다.",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "코디를 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "COORD_102",
+                              "message": "해당 날짜의 코디를 찾을 수 없습니다."
+                            }
+                            """)))
+    })
     @DeleteMapping
     ResponseEntity<SuccessResponse<Void>> deleteCoordination(
             @RequestParam("date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationController.java
@@ -10,14 +10,12 @@ import com.example.codionbe.global.common.success.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/coordination")
 public class CoordinationController implements CoordinationApi {
 
     private final CoordinationService coordinationService;

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/request/CoordinationUpdateRequest.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/request/CoordinationUpdateRequest.java
@@ -1,12 +1,20 @@
 package com.example.codionbe.domain.coordination.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
+@Schema(description = "코디 수정 요청")
 public class CoordinationUpdateRequest {
+
+    @Schema(description = "코디 날짜", example = "2024-05-12")
     private LocalDate date;
+
+    @Schema(description = "수정할 옷 ID 목록", example = "[1, 4, 5]")
     private List<Long> clothesIds;
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/request/CreateCoordinationRequest.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/request/CreateCoordinationRequest.java
@@ -1,12 +1,21 @@
 package com.example.codionbe.domain.coordination.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
 
-@Data
+@Getter
+@NoArgsConstructor
+@Schema(description = "코디 등록 요청")
 public class CreateCoordinationRequest {
+
+    @Schema(description = "코디 날짜", example = "2025-05-12")
     private LocalDate date;
+
+    @Schema(description = "코디에 포함된 옷 ID 목록", example = "[1, 2, 3]")
     private List<Long> clothesIds;
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/response/ClothesSimpleResponse.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/response/ClothesSimpleResponse.java
@@ -1,17 +1,25 @@
 package com.example.codionbe.domain.coordination.dto.response;
 
 import com.example.codionbe.domain.closet.entity.Clothes;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "코디에 포함된 간단한 옷 정보")
 public class ClothesSimpleResponse {
+
+    @Schema(description = "옷 ID", example = "1")
     private Long id;
+
+    @Schema(description = "옷 이름", example = "흰색 셔츠")
     private String name;
+
+    @Schema(description = "이미지 URL", example = "https://example-s3.com/closet/shirt.jpg")
     private String imageUrl;
 
-    public static ClothesSimpleResponse from(Clothes clothes) {
+    public static ClothesSimpleResponse from(com.example.codionbe.domain.closet.entity.Clothes clothes) {
         return new ClothesSimpleResponse(clothes.getId(), clothes.getName(), clothes.getImageUrl());
     }
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/dto/response/CoordinationDetailResponse.java
@@ -1,6 +1,7 @@
 package com.example.codionbe.domain.coordination.dto.response;
 
 import com.example.codionbe.domain.comment.dto.response.CommentResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,9 +10,18 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "코디 상세 조회 응답")
 public class CoordinationDetailResponse {
+
+    @Schema(description = "코디 ID", example = "1")
     private Long coordinationId;
+
+    @Schema(description = "코디 날짜", example = "2024-05-12")
     private LocalDate date;
+
+    @Schema(description = "코디에 포함된 옷 정보 목록")
     private List<ClothesSimpleResponse> clothes;
+
+    @Schema(description = "코디에 남긴 코멘트", nullable = true)
     private CommentResponse comment;
 }

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum CoordinationErrorCode implements ErrorCode {
-    INVALID_CLOTHES(HttpStatus.BAD_REQUEST, "COORD_001", "유효하지 않은 옷 정보입니다."),
-    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COORD_002", "해당 날짜의 코디를 찾을 수 없습니다.");
+    INVALID_CLOTHES(HttpStatus.BAD_REQUEST, "COORD_101", "유효하지 않은 옷 정보입니다."),
+    COORDINATION_NOT_FOUND(HttpStatus.NOT_FOUND, "COORD_102", "해당 날짜의 코디를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/exception/CoordinationSuccessCode.java
@@ -10,8 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum CoordinationSuccessCode implements SuccessCode {
     COORDINATION_CREATE_SUCCESS(HttpStatus.OK, "COORD_001", "코디 등록에 성공했습니다."),
     COORDINATION_UPDATE_SUCCESS(HttpStatus.OK, "COORD_002", "코디 수정에 성공했습니다."),
-    COORDINATION_GET_SUCCESS(HttpStatus.OK, "COORD_005", "코디 상세 조회에 성공했습니다."),
-    COORDINATION_DELETE_SUCCESS(HttpStatus.OK, "COORD_006", "코디 삭제에 성공했습니다.");
+    COORDINATION_GET_SUCCESS(HttpStatus.OK, "COORD_003", "코디 상세 조회에 성공했습니다."),
+    COORDINATION_DELETE_SUCCESS(HttpStatus.OK, "COORD_004", "코디 삭제에 성공했습니다.");
 
 
 

--- a/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/service/CoordinationService.java
@@ -52,7 +52,13 @@ public class CoordinationService {
         coordination.getClothesList().forEach(Clothes::decreaseWearingCount);
 
         // 새 옷 ID들 조회
-        List<Clothes> newClothes = clothesRepository.findAllById(request.getClothesIds());
+        List<Long> requestedIds = request.getClothesIds();
+        List<Clothes> newClothes = clothesRepository.findAllById(requestedIds);
+
+        // 존재하지 않는 옷이 있는지 확인
+        if (newClothes.size() != requestedIds.size()) {
+            throw new CustomException(CoordinationErrorCode.INVALID_CLOTHES);
+        }
 
         // 삭제되었거나 권한 없는 옷 체크
         for (Clothes clothes : newClothes) {

--- a/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
+++ b/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
@@ -2,12 +2,18 @@ package com.example.codionbe.domain.member.controller;
 
 import com.example.codionbe.domain.member.dto.request.LoginRequest;
 import com.example.codionbe.domain.member.dto.request.SignUpRequest;
+import com.example.codionbe.domain.member.dto.request.TokenRefreshRequest;
 import com.example.codionbe.domain.member.dto.response.LoginResponse;
 import com.example.codionbe.domain.member.dto.response.SignUpResponse;
+import com.example.codionbe.domain.member.dto.response.TokenRefreshResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -23,9 +29,35 @@ public interface AuthApi {
 
     @Operation(summary = "회원가입 API", description = "이메일, 비밀번호, 닉네임, 퍼스널컬러 정보를 입력받아 회원가입을 진행합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원가입 성공"),
-            @ApiResponse(responseCode = "400", description = "입력값 오류 또는 이메일 중복"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_001",
+                              "message": "회원가입이 성공적으로 완료되었습니다.",
+                              "data": {
+                                "userId": 1,
+                                "email": "test@example.com",
+                                "nickname": "홍길동"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "400", description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_102",
+                              "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "409", description = "이메일 중복",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_101",
+                              "message": "이미 사용 중인 이메일입니다."
+                            }
+                            """)))
     })
     @PostMapping("/signup")
     ResponseEntity<SuccessResponse<SignUpResponse>> signup(
@@ -34,13 +66,65 @@ public interface AuthApi {
 
     @Operation(summary = "로그인 API", description = "이메일과 비밀번호로 로그인을 시도하고 토큰을 발급받습니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "401", description = "비밀번호 불일치 또는 존재하지 않는 사용자"),
-            @ApiResponse(responseCode = "500", description = "서버 오류")
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_002",
+                              "message": "로그인이 성공적으로 완료되었습니다.",
+                              "data": {
+                                "accessToken": "access-token-value",
+                                "refreshToken": "refresh-token-value"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_104",
+                              "message": "비밀번호가 일치하지 않습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_103",
+                              "message": "사용자를 찾을 수 없습니다."
+                            }
+                            """)))
     })
     @PostMapping("/login")
     ResponseEntity<SuccessResponse<LoginResponse>> login(
             @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "로그인 요청") LoginRequest request
+    );
+
+    @Operation(summary = "AccessToken 재발급 API", description = "RefreshToken을 기반으로 새로운 AccessToken을 발급합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "재발급 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_003",
+                              "message": "토큰이 성공적으로 재발급되었습니다.",
+                              "data": {
+                                "accessToken": "new-access-token-value"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "유효하지 않은 토큰",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_107",
+                              "message": "유효하지 않은 JWT 토큰입니다."
+                            }
+                            """)))
+    })
+    @PostMapping("/refresh")
+    ResponseEntity<SuccessResponse<TokenRefreshResponse>> refresh(
+            @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "RefreshToken 요청") TokenRefreshRequest request
     );
 
     @Operation(
@@ -49,8 +133,23 @@ public interface AuthApi {
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_004",
+                              "message": "로그아웃 성공",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_105",
+                              "message": "인증 정보가 유효하지 않습니다."
+                            }
+                            """)))
     })
     @DeleteMapping("/logout")
     ResponseEntity<SuccessResponse<Void>> logout(

--- a/src/main/java/com/example/codionbe/domain/member/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/request/LoginRequest.java
@@ -1,11 +1,17 @@
 package com.example.codionbe.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "로그인 요청")
 public class LoginRequest {
+
+    @Schema(description = "이메일", example = "test@example.com")
     private String email;
+
+    @Schema(description = "비밀번호", example = "securePassword123!")
     private String password;
 }

--- a/src/main/java/com/example/codionbe/domain/member/dto/request/SignUpRequest.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/request/SignUpRequest.java
@@ -1,14 +1,26 @@
 package com.example.codionbe.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "회원가입 요청")
 public class SignUpRequest {
+
+    @Schema(description = "이메일", example = "test@example.com")
     private String email;
+
+    @Schema(description = "비밀번호", example = "securePassword123!")
     private String password;
+
+    @Schema(description = "비밀번호 확인", example = "securePassword123!")
     private String passwordCheck;
+
+    @Schema(description = "닉네임", example = "홍길동")
     private String nickname;
+
+    @Schema(description = "퍼스널컬러", example = "SPRING")
     private String personalColor;
 }

--- a/src/main/java/com/example/codionbe/domain/member/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/request/TokenRefreshRequest.java
@@ -1,10 +1,15 @@
 package com.example.codionbe.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "AccessToken 재발급 요청")
 public class TokenRefreshRequest {
+
+    @Schema(description = "Refresh Token", example = "refresh-token-value")
     private String refreshToken;
 }
+

--- a/src/main/java/com/example/codionbe/domain/member/dto/response/LoginResponse.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/response/LoginResponse.java
@@ -1,11 +1,17 @@
 package com.example.codionbe.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "로그인 응답")
 public class LoginResponse {
+
+    @Schema(description = "Access Token", example = "access-token-value")
     private String accessToken;
+
+    @Schema(description = "Refresh Token", example = "refresh-token-value")
     private String refreshToken;
 }

--- a/src/main/java/com/example/codionbe/domain/member/dto/response/SignUpResponse.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/response/SignUpResponse.java
@@ -1,12 +1,20 @@
 package com.example.codionbe.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "회원가입 응답")
 public class SignUpResponse {
+
+    @Schema(description = "회원 ID", example = "1")
     private Long id;
+
+    @Schema(description = "이메일", example = "test@example.com")
     private String email;
+
+    @Schema(description = "닉네임", example = "홍길동")
     private String nickname;
 }

--- a/src/main/java/com/example/codionbe/domain/member/dto/response/TokenRefreshResponse.java
+++ b/src/main/java/com/example/codionbe/domain/member/dto/response/TokenRefreshResponse.java
@@ -1,10 +1,14 @@
 package com.example.codionbe.domain.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "AccessToken 재발급 응답")
 public class TokenRefreshResponse {
+
+    @Schema(description = "새로운 Access Token", example = "new-access-token-value")
     private String accessToken;
 }

--- a/src/main/java/com/example/codionbe/domain/member/exception/AuthErrorCode.java
+++ b/src/main/java/com/example/codionbe/domain/member/exception/AuthErrorCode.java
@@ -5,13 +5,13 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthErrorCode implements ErrorCode {
 
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409", "이미 사용 중인 이메일입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_400", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_404", "사용자를 찾을 수 없습니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_401", "비밀번호가 일치하지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_401", "인증 정보가 유효하지 않습니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_401", "JWT 토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401", "유효하지 않은 JWT 토큰입니다.");
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_101", "이미 사용 중인 이메일입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_102", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH_103", "사용자를 찾을 수 없습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_104", "비밀번호가 일치하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH_105", "인증 정보가 유효하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_106", "JWT 토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_107", "유효하지 않은 JWT 토큰입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/member/exception/AuthSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/member/exception/AuthSuccessCode.java
@@ -5,10 +5,10 @@ import org.springframework.http.HttpStatus;
 
 public enum AuthSuccessCode implements SuccessCode {
 
-    SIGNUP_SUCCESS(HttpStatus.OK, "AUTH_200", "회원가입이 성공적으로 완료되었습니다."),
-    LOGIN_SUCCESS(HttpStatus.OK, "AUTH_201", "로그인이 성공적으로 완료되었습니다."),
-    TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "AUTH_202", "토큰이 성공적으로 재발급되었습니다."),
-    LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_204", "로그아웃 성공");
+    SIGNUP_SUCCESS(HttpStatus.OK, "AUTH_001", "회원가입이 성공적으로 완료되었습니다."),
+    LOGIN_SUCCESS(HttpStatus.OK, "AUTH_002", "로그인이 성공적으로 완료되었습니다."),
+    TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "AUTH_003", "토큰이 성공적으로 재발급되었습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_004", "로그아웃 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/domain/member/service/AuthService.java
+++ b/src/main/java/com/example/codionbe/domain/member/service/AuthService.java
@@ -91,6 +91,9 @@ public class AuthService {
 
     @Transactional
     public void logout(Long userId) {
-        refreshTokenRepository.deleteById(userId);
+        RefreshToken token = refreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.UNAUTHORIZED));
+
+        refreshTokenRepository.delete(token);
     }
 }

--- a/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
@@ -4,9 +4,13 @@ import com.example.codionbe.domain.mypage.dto.request.UpdatePasswordRequest;
 import com.example.codionbe.domain.mypage.dto.request.UpdateProfileRequest;
 import com.example.codionbe.domain.mypage.dto.response.MyPageResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
+import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -27,8 +31,27 @@ public interface MyPageApi {
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "MYPAGE_001",
+                              "message": "회원 정보 조회 성공",
+                              "data": {
+                                "email": "test@example.com",
+                                "nickname": "홍길동",
+                                "personalColor": "SPRING"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "인증 정보가 유효하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_105",
+                              "message": "인증 정보가 유효하지 않습니다."
+                            }
+                            """)))
     })
     @GetMapping("")
     ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
@@ -41,9 +64,27 @@ public interface MyPageApi {
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공"),
-            @ApiResponse(responseCode = "400", description = "입력값 오류"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "MYPAGE_002",
+                              "message": "회원 정보 수정 성공",
+                              "data": {
+                                "email": "test@example.com",
+                                "nickname": "변경된이름",
+                                "personalColor": "SUMMER"
+                              }
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "인증 정보가 유효하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_105",
+                              "message": "인증 정보가 유효하지 않습니다."
+                            }
+                            """)))
     })
     @PatchMapping("")
     ResponseEntity<SuccessResponse<MyPageResponse>> updateProfile(
@@ -57,9 +98,31 @@ public interface MyPageApi {
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
-            @ApiResponse(responseCode = "400", description = "비밀번호 불일치"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "MYPAGE_003",
+                              "message": "비밀번호 변경 성공",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "400", description = "비밀번호 불일치",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_102",
+                              "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다."
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "인증 정보가 유효하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_105",
+                              "message": "인증 정보가 유효하지 않습니다."
+                            }
+                            """)))
     })
     @PatchMapping("/password")
     ResponseEntity<SuccessResponse<Void>> updatePassword(
@@ -73,8 +136,23 @@ public interface MyPageApi {
             security = @SecurityRequirement(name = "bearerAuth")
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "MYPAGE_004",
+                              "message": "회원 탈퇴 성공",
+                              "data": null
+                            }
+                            """))),
+            @ApiResponse(responseCode = "401", description = "인증 정보가 유효하지 않습니다.",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "code": "AUTH_105",
+                              "message": "인증 정보가 유효하지 않습니다."
+                            }
+                            """)))
     })
     @DeleteMapping
     ResponseEntity<SuccessResponse<Void>> deleteUser(

--- a/src/main/java/com/example/codionbe/domain/mypage/dto/request/UpdatePasswordRequest.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/dto/request/UpdatePasswordRequest.java
@@ -1,11 +1,18 @@
 package com.example.codionbe.domain.mypage.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "비밀번호 변경 요청")
 public class UpdatePasswordRequest {
+
+    @Schema(description = "새 비밀번호", example = "newSecurePass123!")
     private String newPassword;
+
+    @Schema(description = "새 비밀번호 확인", example = "newSecurePass123!")
     private String newPasswordCheck;
 }
+

--- a/src/main/java/com/example/codionbe/domain/mypage/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/dto/request/UpdateProfileRequest.java
@@ -1,11 +1,17 @@
 package com.example.codionbe.domain.mypage.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(description = "프로필 수정 요청")
 public class UpdateProfileRequest {
+
+    @Schema(description = "변경할 닉네임", example = "변경된닉네임")
     private String nickname;
+
+    @Schema(description = "변경할 퍼스널컬러", example = "AUTUMN")
     private String personalColor;
 }

--- a/src/main/java/com/example/codionbe/domain/mypage/dto/response/MyPageResponse.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/dto/response/MyPageResponse.java
@@ -1,12 +1,20 @@
 package com.example.codionbe.domain.mypage.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
+@Schema(description = "마이페이지 응답")
 public class MyPageResponse {
+
+    @Schema(description = "이메일", example = "test@example.com")
     private String email;
+
+    @Schema(description = "닉네임", example = "홍길동")
     private String nickname;
+
+    @Schema(description = "퍼스널컬러", example = "SPRING")
     private String personalColor;
 }

--- a/src/main/java/com/example/codionbe/domain/mypage/exception/MyPageSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/exception/MyPageSuccessCode.java
@@ -5,10 +5,10 @@ import org.springframework.http.HttpStatus;
 
 public enum MyPageSuccessCode implements SuccessCode {
 
-    MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_200", "회원 정보 조회 성공"),
-    MYPAGE_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE_201", "회원 정보 수정 성공"),
-    PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE_202", "비밀번호 변경 성공"),
-    USER_DELETE_SUCCESS(HttpStatus.OK, "MYPAGE_203", "회원 탈퇴 성공");
+    MYPAGE_GET_SUCCESS(HttpStatus.OK, "MYPAGE_001", "회원 정보 조회 성공"),
+    MYPAGE_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE_002", "회원 정보 수정 성공"),
+    PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, "MYPAGE_003", "비밀번호 변경 성공"),
+    USER_DELETE_SUCCESS(HttpStatus.OK, "MYPAGE_004", "회원 탈퇴 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/example/codionbe/global/common/exception/ErrorResponse.java
+++ b/src/main/java/com/example/codionbe/global/common/exception/ErrorResponse.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "에러 응답 포맷")
 public class ErrorResponse {
+    @Schema(description = "에러 코드", example = "AUTH_401")
     private final String code;
+    @Schema(description = "에러 메시지", example = "비밀번호가 일치하지 않습니다.")
     private final String message;
 
     public ErrorResponse(String code, String message) {

--- a/src/main/java/com/example/codionbe/global/common/success/SuccessResponse.java
+++ b/src/main/java/com/example/codionbe/global/common/success/SuccessResponse.java
@@ -4,8 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "성공 응답 포맷")
 public class SuccessResponse<T> {
+    @Schema(description = "성공 코드", example = "AUTH_201")
     private final String code;
+    @Schema(description = "성공 메시지", example = "로그인이 성공적으로 완료되었습니다.")
     private final String message;
+    @Schema(description = "응답 데이터", nullable = true)
     private final T data;
 
     public SuccessResponse(SuccessCode successCode, T data) {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #41 

## 🔑 Key Changes

1. 내용
    - Auth, MyPage, Closet, Coordination, Comment 도메인에 Swagger 문서화 적용
    - 요청/응답 DTO에 @Schema, example 추가
    - SuccessResponse, ErrorResponse에 공통 포맷 및 예시 적용
    - 각 API에 실제 반환 형태 기반의 @ApiResponses 구성
    - 비정상 요청에 대한 에러 응답도 명확히 정의

## 📸 Screenshot
