### PR TITLE
Feat: 공통 응답 객체에 isSuccess 필드 추가

### DIFF
--- a/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
+++ b/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
@@ -17,11 +17,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,6 +34,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_007",
                               "message": "이미지 분석에 성공했습니다.",
                               "data": {
@@ -59,6 +58,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_001",
                               "message": "옷 등록에 성공했습니다.",
                               "data": null
@@ -77,6 +77,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_002",
                               "message": "MY 옷장 목록 조회에 성공했습니다.",
                               "data": [ ]
@@ -95,6 +96,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_003",
                               "message": "옷 수정에 성공했습니다.",
                               "data": null
@@ -104,6 +106,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "CLOSET_101",
                               "message": "해당 옷을 찾을 수 없습니다."
                             }
@@ -112,6 +115,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "CLOSET_102",
                               "message": "해당 옷에 대한 권한이 없습니다."
                             }
@@ -130,6 +134,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_004",
                               "message": "옷 삭제에 성공했습니다.",
                               "data": null
@@ -148,6 +153,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_006",
                               "message": "옷 상세 조회에 성공했습니다.",
                               "data": {
@@ -177,6 +183,7 @@ public interface ClosetApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "CLOSET_005",
                               "message": "즐겨찾기 상태가 변경되었습니다.",
                               "data": {

--- a/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
+++ b/src/main/java/com/example/codionbe/domain/comment/controller/CommentApi.java
@@ -30,6 +30,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COMMENT_001",
                               "message": "코멘트 등록에 성공했습니다.",
                               "data": null
@@ -39,6 +40,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COMMENT_102",
                               "message": "이미 코멘트가 등록되어 있습니다."
                             }
@@ -47,6 +49,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COMMENT_103",
                               "message": "해당 날짜의 코디가 존재하지 않습니다."
                             }
@@ -63,6 +66,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COMMENT_002",
                               "message": "코멘트 수정에 성공했습니다.",
                               "data": null
@@ -72,6 +76,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COMMENT_103",
                               "message": "해당 날짜의 코디가 존재하지 않습니다."
                             }
@@ -88,6 +93,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COMMENT_003",
                               "message": "코멘트 삭제에 성공했습니다.",
                               "data": null
@@ -97,6 +103,7 @@ public interface CommentApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COMMENT_103",
                               "message": "해당 날짜의 코디가 존재하지 않습니다."
                             }

--- a/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
+++ b/src/main/java/com/example/codionbe/domain/coordination/controller/CoordinationApi.java
@@ -31,6 +31,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COORD_001",
                               "message": "코디 등록에 성공했습니다.",
                               "data": null
@@ -48,6 +49,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COORD_002",
                               "message": "코디 수정에 성공했습니다.",
                               "data": null
@@ -57,6 +59,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COORD_101",
                               "message": "유효하지 않은 옷 정보입니다."
                             }
@@ -73,6 +76,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COORD_003",
                               "message": "코디 상세 조회에 성공했습니다.",
                               "data": {
@@ -87,6 +91,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COORD_102",
                               "message": "해당 날짜의 코디를 찾을 수 없습니다."
                             }
@@ -103,6 +108,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "COORD_004",
                               "message": "코디 삭제에 성공했습니다.",
                               "data": null
@@ -112,6 +118,7 @@ public interface CoordinationApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "COORD_102",
                               "message": "해당 날짜의 코디를 찾을 수 없습니다."
                             }

--- a/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
+++ b/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
@@ -33,6 +33,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "AUTH_001",
                               "message": "회원가입이 성공적으로 완료되었습니다.",
                               "data": {
@@ -46,6 +47,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_102",
                               "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다."
                             }
@@ -54,6 +56,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_101",
                               "message": "이미 사용 중인 이메일입니다."
                             }
@@ -70,6 +73,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "AUTH_002",
                               "message": "로그인이 성공적으로 완료되었습니다.",
                               "data": {
@@ -82,6 +86,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_104",
                               "message": "비밀번호가 일치하지 않습니다."
                             }
@@ -90,6 +95,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_103",
                               "message": "사용자를 찾을 수 없습니다."
                             }
@@ -106,6 +112,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "AUTH_003",
                               "message": "토큰이 성공적으로 재발급되었습니다.",
                               "data": {
@@ -117,6 +124,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_107",
                               "message": "유효하지 않은 JWT 토큰입니다."
                             }
@@ -137,6 +145,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "AUTH_004",
                               "message": "로그아웃 성공",
                               "data": null
@@ -146,6 +155,7 @@ public interface AuthApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_105",
                               "message": "인증 정보가 유효하지 않습니다."
                             }

--- a/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
@@ -35,6 +35,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "MYPAGE_001",
                               "message": "회원 정보 조회 성공",
                               "data": {
@@ -48,6 +49,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_105",
                               "message": "인증 정보가 유효하지 않습니다."
                             }
@@ -68,6 +70,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "MYPAGE_002",
                               "message": "회원 정보 수정 성공",
                               "data": {
@@ -81,6 +84,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_105",
                               "message": "인증 정보가 유효하지 않습니다."
                             }
@@ -102,6 +106,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "MYPAGE_003",
                               "message": "비밀번호 변경 성공",
                               "data": null
@@ -111,6 +116,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_102",
                               "message": "비밀번호와 비밀번호 확인이 일치하지 않습니다."
                             }
@@ -119,6 +125,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_105",
                               "message": "인증 정보가 유효하지 않습니다."
                             }
@@ -140,6 +147,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": true,
                               "code": "MYPAGE_004",
                               "message": "회원 탈퇴 성공",
                               "data": null
@@ -149,6 +157,7 @@ public interface MyPageApi {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                             examples = @ExampleObject(value = """
                             {
+                              "isSuccess": false,
                               "code": "AUTH_105",
                               "message": "인증 정보가 유효하지 않습니다."
                             }

--- a/src/main/java/com/example/codionbe/global/common/exception/ErrorResponse.java
+++ b/src/main/java/com/example/codionbe/global/common/exception/ErrorResponse.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "에러 응답 포맷")
 public class ErrorResponse {
+    @Schema(description = "요청 성공 여부", example = "false")
+    private final boolean isSuccess = false;
     @Schema(description = "에러 코드", example = "AUTH_401")
     private final String code;
     @Schema(description = "에러 메시지", example = "비밀번호가 일치하지 않습니다.")
@@ -12,6 +14,10 @@ public class ErrorResponse {
     public ErrorResponse(String code, String message) {
         this.code = code;
         this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return isSuccess;
     }
 
     public String getCode() {

--- a/src/main/java/com/example/codionbe/global/common/success/SuccessResponse.java
+++ b/src/main/java/com/example/codionbe/global/common/success/SuccessResponse.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "성공 응답 포맷")
 public class SuccessResponse<T> {
+    @Schema(description = "요청 성공 여부", example = "true")
+    private final boolean isSuccess = true;
     @Schema(description = "성공 코드", example = "AUTH_201")
     private final String code;
     @Schema(description = "성공 메시지", example = "로그인이 성공적으로 완료되었습니다.")
@@ -15,6 +17,10 @@ public class SuccessResponse<T> {
         this.code = successCode.getCode();
         this.message = successCode.getMessage();
         this.data = data;
+    }
+
+    public boolean isSuccess() {
+        return isSuccess;
     }
 
     public String getCode() {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #44 

## 🔑 Key Changes

1. 내용
    - SuccessResponse 및 ErrorResponse에 isSuccess(boolean) 필드 추가
    - 각 API의 Swagger 응답 예시에 isSuccess 포함되도록 수정
    - 프론트 요청에 따라 응답 성공 여부를 명확히 구분할 수 있도록 개선

## 📸 Screenshot
