### PR TITLE
Feat: 퍼스널컬러 분석 API 구현

### DIFF
--- a/src/main/java/com/example/codionbe/domain/personalColor/controller/PersonalColorApi.java
+++ b/src/main/java/com/example/codionbe/domain/personalColor/controller/PersonalColorApi.java
@@ -1,0 +1,43 @@
+package com.example.codionbe.domain.personalColor.controller;
+
+import com.example.codionbe.domain.personalColor.dto.PersonalColorResponse;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Tag(name = "퍼스널 컬러", description = "퍼스널 컬러 관련 API")
+@RequestMapping("/personal-color")
+public interface PersonalColorApi {
+
+    @Operation(summary = "퍼스널컬러 분석 API", description = "카메라를 통한 퍼스널컬러 분석합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퍼스널컬러 분석 성공",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = """
+                            {
+                              "isSuccess": true,
+                              "code": "PERSONAL_COLOR_001",
+                              "message": "퍼스널컬러 분석에 성공했습니다.",
+                              "data": {
+                                "personalColor": "봄 웜"
+                              }
+                            }
+                            """)))
+    })
+    @PostMapping("/analyze")
+    ResponseEntity<SuccessResponse<PersonalColorResponse>> analyzePersonalColor(
+            @RequestPart("image") MultipartFile image
+    ) throws IOException;
+}

--- a/src/main/java/com/example/codionbe/domain/personalColor/controller/PersonalColorController.java
+++ b/src/main/java/com/example/codionbe/domain/personalColor/controller/PersonalColorController.java
@@ -1,0 +1,27 @@
+package com.example.codionbe.domain.personalColor.controller;
+
+import com.example.codionbe.domain.personalColor.dto.PersonalColorResponse;
+import com.example.codionbe.domain.personalColor.exception.PersonalColorSuccessCode;
+import com.example.codionbe.domain.personalColor.service.PersonalColorService;
+import com.example.codionbe.global.common.success.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+public class PersonalColorController implements PersonalColorApi {
+
+    private final PersonalColorService personalColorService;
+
+    @Override
+    public ResponseEntity<SuccessResponse<PersonalColorResponse>> analyzePersonalColor(
+            MultipartFile image) throws IOException {
+
+        PersonalColorResponse response = personalColorService.analyzePersonalColor(image);
+        return ResponseEntity.ok(new SuccessResponse<>(PersonalColorSuccessCode.PERSONAL_COLOR_ANALYSIS_SUCCESS, response));
+    }
+}

--- a/src/main/java/com/example/codionbe/domain/personalColor/dto/PersonalColorResponse.java
+++ b/src/main/java/com/example/codionbe/domain/personalColor/dto/PersonalColorResponse.java
@@ -1,0 +1,14 @@
+package com.example.codionbe.domain.personalColor.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "퍼스널컬러 분석 응답")
+public class PersonalColorResponse {
+
+    @Schema(description = "퍼스널컬러", example = "여름 쿨")
+    private String personalColor;
+}

--- a/src/main/java/com/example/codionbe/domain/personalColor/exception/PersonalColorSuccessCode.java
+++ b/src/main/java/com/example/codionbe/domain/personalColor/exception/PersonalColorSuccessCode.java
@@ -1,0 +1,17 @@
+package com.example.codionbe.domain.personalColor.exception;
+
+import com.example.codionbe.global.common.success.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PersonalColorSuccessCode implements SuccessCode {
+
+    PERSONAL_COLOR_ANALYSIS_SUCCESS(HttpStatus.OK, "PERSONAL_COLOR_001", "퍼스널컬러 분석에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/codionbe/domain/personalColor/service/PersonalColorService.java
+++ b/src/main/java/com/example/codionbe/domain/personalColor/service/PersonalColorService.java
@@ -1,0 +1,29 @@
+package com.example.codionbe.domain.personalColor.service;
+
+import com.example.codionbe.domain.personalColor.dto.PersonalColorResponse;
+import com.example.codionbe.global.s3.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class PersonalColorService {
+
+    private final S3Uploader s3Uploader;
+
+    @Transactional
+    public PersonalColorResponse analyzePersonalColor(MultipartFile image) throws IOException {
+
+        String imageUrl = s3Uploader.upload(image, "personalColor");
+
+        // 퍼스널컬러 분석하기
+
+        String personalColor = "여름 쿨";
+
+        return new PersonalColorResponse(personalColor);
+    }
+}

--- a/src/main/java/com/example/codionbe/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/codionbe/global/config/SecurityConfig.java
@@ -26,7 +26,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/oauth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/auth/**", "/oauth/**", "/swagger-ui/**", "/v3/api-docs/**",
+                                "/personal-color/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #48 

## 🔑 Key Changes

1. 내용
    - 퍼스널컬러 분석 API를 세팅했다.
    - 회원가입 시 같이 진행하는 api라 securityConfig에 permit 추가를 해두었다.
    - 나중에 마이페이지에서도 퍼스널컬러 수정할 때 같이 쓸 수 있을 듯 하다.

## 📸 Screenshot
