### PR TITLE
Refactor: API 명세 분리 구조에서 매핑 어노테이션 위치 통일

### DIFF
--- a/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
+++ b/src/main/java/com/example/codionbe/domain/member/controller/AuthApi.java
@@ -18,12 +18,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "회원", description = "회원 관련 API")
+@RequestMapping("/auth")
 public interface AuthApi {
 
     @Operation(summary = "회원가입 API", description = "이메일, 비밀번호, 닉네임, 퍼스널컬러 정보를 입력받아 회원가입을 진행합니다.")

--- a/src/main/java/com/example/codionbe/domain/member/controller/AuthController.java
+++ b/src/main/java/com/example/codionbe/domain/member/controller/AuthController.java
@@ -15,32 +15,27 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
 public class AuthController implements AuthApi {
 
     private final AuthService authService;
 
     @Override
-    @PostMapping("/signup")
     public ResponseEntity<SuccessResponse<SignUpResponse>> signup(@RequestBody SignUpRequest request) {
         SignUpResponse response = authService.signup(request);
         return ResponseEntity.ok(new SuccessResponse<>(AuthSuccessCode.SIGNUP_SUCCESS, response));
     }
 
     @Override
-    @PostMapping("/login")
     public ResponseEntity<SuccessResponse<LoginResponse>> login(@RequestBody LoginRequest request) {
         LoginResponse response = authService.login(request);
         return ResponseEntity.ok(new SuccessResponse<>(AuthSuccessCode.LOGIN_SUCCESS, response));
     }
 
-    @PostMapping("/refresh")
     public ResponseEntity<SuccessResponse<TokenRefreshResponse>> refresh(@RequestBody TokenRefreshRequest request) {
         TokenRefreshResponse response = authService.refreshAccessToken(request.getRefreshToken());
         return ResponseEntity.ok(new SuccessResponse<>(AuthSuccessCode.TOKEN_REFRESH_SUCCESS, response));
     }
 
-    @DeleteMapping("/logout")
     @Override
     public ResponseEntity<SuccessResponse<Void>> logout(@AuthenticationPrincipal CustomUserDetails userDetails) {
         authService.logout(userDetails.getUser().getId());
@@ -48,14 +43,12 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    @PostMapping("/kakao")
     public ResponseEntity<SuccessResponse<LoginResponse>> kakaoLogin(@RequestBody KakaoLoginRequest request) {
         LoginResponse response = authService.kakaoLogin(request.getCode());
         return ResponseEntity.ok(new SuccessResponse<>(AuthSuccessCode.LOGIN_SUCCESS, response));
     }
 
     @Override
-    @PatchMapping("/complete-social")
     public ResponseEntity<SuccessResponse<Void>> completeSocialSignup(
             CompleteSocialSignupRequest request,
             CustomUserDetails userDetails) {

--- a/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageApi.java
@@ -17,12 +17,10 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "마이페이지", description = "마이페이지 관련 API")
+@RequestMapping("/mypage")
 public interface MyPageApi {
 
     @Operation(
@@ -55,7 +53,7 @@ public interface MyPageApi {
                             }
                             """)))
     })
-    @GetMapping("")
+    @GetMapping
     ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
     );
@@ -90,7 +88,7 @@ public interface MyPageApi {
                             }
                             """)))
     })
-    @PatchMapping("")
+    @PatchMapping
     ResponseEntity<SuccessResponse<MyPageResponse>> updateProfile(
             @RequestBody @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "회원 프로필 수정 요청") UpdateProfileRequest request,
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/example/codionbe/domain/mypage/controller/MyPageController.java
@@ -14,13 +14,11 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/mypage")
 public class MyPageController implements MyPageApi {
 
     private final MyPageService myPageService;
 
     @Override
-    @GetMapping("")
     public ResponseEntity<SuccessResponse<MyPageResponse>> getMyPage(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
@@ -29,7 +27,6 @@ public class MyPageController implements MyPageApi {
     }
 
     @Override
-    @PatchMapping("")
     public ResponseEntity<SuccessResponse<MyPageResponse>> updateProfile(
             @RequestBody UpdateProfileRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -39,7 +36,6 @@ public class MyPageController implements MyPageApi {
     }
 
     @Override
-    @PatchMapping("/password")
     public ResponseEntity<SuccessResponse<Void>> updatePassword(
             @RequestBody UpdatePasswordRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -49,7 +45,6 @@ public class MyPageController implements MyPageApi {
     }
 
     @Override
-    @DeleteMapping
     public ResponseEntity<SuccessResponse<Void>> deleteUser(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #50 

## 🔑 Key Changes

1. 내용
    - @RequestMapping, @PostMapping, @GetMapping 등의 매핑 어노테이션을 Api 인터페이스로 이동
    - Controller에서는 매핑 어노테이션 제거하고 구현만 유지
    - Swagger 관련 어노테이션 (@Operation, @ApiResponse)도 Api에 집중시켜 문서 명세를 통일
    - 중복된 경로 정의 제거

## 📸 Screenshot
