### PR TITLE
Feat: 옷 카테고리를 대분류/소분류 구조로 확장

### DIFF
--- a/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
+++ b/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
@@ -24,7 +24,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 @Tag(name = "MY 옷장", description = "MY 옷장 관련 API")
 @RequestMapping("/closet")

--- a/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
+++ b/src/main/java/com/example/codionbe/domain/closet/controller/ClosetApi.java
@@ -6,7 +6,6 @@ import com.example.codionbe.domain.closet.dto.request.UpdateClothesRequest;
 import com.example.codionbe.domain.closet.dto.response.ClothesAnalysisResponse;
 import com.example.codionbe.domain.closet.dto.response.ClothesResponse;
 import com.example.codionbe.domain.closet.dto.response.FavoriteToggleResponse;
-import com.example.codionbe.domain.closet.dto.response.ImageAnalysisResponse;
 import com.example.codionbe.global.auth.CustomUserDetails;
 import com.example.codionbe.global.common.exception.ErrorResponse;
 import com.example.codionbe.global.common.success.SuccessResponse;
@@ -146,11 +145,12 @@ public interface ClosetApi {
                                 "clothesId": 1,
                                 "name": "화이트 셔츠",
                                 "imageUrl": "https://s3.amazonaws.com/bucket/image.jpg",
-                                "category": "TOP",
                                 "personalColor": "SUMMER",
                                 "color": "WHITE",
                                 "situationKeywords": ["데이트", "면접"],
                                 "wearCount": 0,
+                                "category": "TOP",
+                                "subCategory": "SHORT_SLEEVE",
                                 "favorite": false,
                                 "wearableWhenRainy": true
                               }

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/ClothesFilterRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/ClothesFilterRequest.java
@@ -1,5 +1,6 @@
 package com.example.codionbe.domain.closet.dto.request;
 
+import com.example.codionbe.domain.closet.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,6 +15,8 @@ import java.util.List;
 @AllArgsConstructor
 @Schema(description = "옷 필터 요청")
 public class ClothesFilterRequest {
+    @Schema(description = "대분류 카테고리", example = "OUTER") // 예: OUTER, TOP, BOTTOM, DRESS
+    private Category category;
 
     @Schema(description = "퍼스널컬러", example = "봄 웜")
     private String personalColor;

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/RegisterClothesRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/RegisterClothesRequest.java
@@ -12,8 +12,8 @@ public class RegisterClothesRequest {
     @Schema(description = "옷 이름", example = "화이트 셔츠")
     private String name;
 
-    @Schema(description = "카테고리", example = "TOP")
-    private String category;
+    @Schema(description = "소분류 카테고리", example = "SHORT_SLEEVE")
+    private String subCategory;
 
     @Schema(description = "퍼스널컬러", example = "SUMMER")
     private String personalColor;

--- a/src/main/java/com/example/codionbe/domain/closet/dto/request/UpdateClothesRequest.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/request/UpdateClothesRequest.java
@@ -12,8 +12,8 @@ public class UpdateClothesRequest {
     @Schema(description = "옷 이름", example = "화이트 셔츠")
     private String name;
 
-    @Schema(description = "카테고리", example = "TOP")
-    private String category;
+    @Schema(description = "소분류 카테고리", example = "SHORT_SLEEVE")
+    private String subCategory;
 
     @Schema(description = "퍼스널컬러", example = "SUMMER")
     private String personalColor;

--- a/src/main/java/com/example/codionbe/domain/closet/dto/response/ClothesResponse.java
+++ b/src/main/java/com/example/codionbe/domain/closet/dto/response/ClothesResponse.java
@@ -1,6 +1,8 @@
 package com.example.codionbe.domain.closet.dto.response;
 
+import com.example.codionbe.domain.closet.entity.Category;
 import com.example.codionbe.domain.closet.entity.Clothes;
+import com.example.codionbe.domain.closet.entity.SubCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,9 +24,6 @@ public class ClothesResponse {
     @Schema(description = "이미지 URL", example = "https://s3.amazonaws.com/bucket/image.jpg")
     private String imageUrl;
 
-    @Schema(description = "카테고리", example = "TOP")
-    private String category;
-
     @Schema(description = "퍼스널컬러", example = "SUMMER")
     private String personalColor;
 
@@ -43,19 +42,26 @@ public class ClothesResponse {
     @Schema(description = "착용 횟수", example = "3")
     private int wearCount;
 
+    @Schema(description = "대분류 카테고리", example = "OUTER")
+    private Category category;
+
+    @Schema(description = "소분류 카테고리", example = "CARDIGAN")
+    private SubCategory subCategory;
+
     public static ClothesResponse from(Clothes c) {
         return new ClothesResponse(
                 c.getId(),
                 c.getName(),
                 c.getImageUrl(),
-                c.getCategory(),
                 c.getPersonalColor(),
                 c.getColor(),
                 Arrays.asList(c.getSituationKeywords().split(",")),
 //                "", // 추후 perceivedTemperature 추가 시 반영
                 c.isSuitableForRain(),
                 c.isFavorite(),
-                c.getWearCount()
+                c.getWearCount(),
+                c.getCategory(),          // <- getCategory()는 Clothes 내부에서 subCategory 기준으로 계산
+                c.getSubCategory()        // <- 저장된 enum 값 그대로 전달
         );
     }
 }

--- a/src/main/java/com/example/codionbe/domain/closet/entity/Category.java
+++ b/src/main/java/com/example/codionbe/domain/closet/entity/Category.java
@@ -9,8 +9,8 @@ public enum Category {
     TOP("상의"),
     OUTER("아우터"),
     BOTTOM("바지"),
-    DRESS("원피스"),
-    SKIRT("스커트");
+    DRESS("원피스/스커트");
+//    SKIRT("스커트");
 
     private final String displayName;
 } 

--- a/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
+++ b/src/main/java/com/example/codionbe/domain/closet/entity/Clothes.java
@@ -1,9 +1,6 @@
 package com.example.codionbe.domain.closet.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +23,9 @@ public class Clothes {
 
     private String name; // 별명
 
-    private String category; // "상의", "아우터", "바지", "원피스/스커트"
+    @Enumerated(EnumType.STRING)
+    private SubCategory subCategory;
+
     private String personalColor; // 예: "봄 웜"
     private String color; // 예: "베이지", "블랙"
 
@@ -67,10 +66,14 @@ public class Clothes {
         }
     }
 
-    public void updateInfo(String name, String category, String personalColor, String color,
+    public Category getCategory() {
+        return subCategory.getParentCategory(); // 이걸로 대분류 유추
+    }
+
+    public void updateInfo(String name, String subCategory, String personalColor, String color,
                            Boolean suitableForRain, List<String> situationKeywords) {
         this.name = name;
-        this.category = category;
+        this.subCategory = SubCategory.valueOf(subCategory);
         this.personalColor = personalColor;
         this.color = color;
         this.suitableForRain = suitableForRain;

--- a/src/main/java/com/example/codionbe/domain/closet/entity/SubCategory.java
+++ b/src/main/java/com/example/codionbe/domain/closet/entity/SubCategory.java
@@ -1,0 +1,31 @@
+package com.example.codionbe.domain.closet.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubCategory {
+    // TOP
+    SHORT_SLEEVE("반팔", Category.TOP),
+    LONG_SLEEVE("긴팔", Category.TOP),
+
+    // OUTER
+    WINDBREAKER("바람막이", Category.OUTER),
+    CARDIGAN("가디건", Category.OUTER),
+    JACKET("재킷", Category.OUTER),
+    PADDING("패딩", Category.OUTER),
+
+    // BOTTOM
+    SHORTS("반바지", Category.BOTTOM),
+    LONG_PANTS("긴바지", Category.BOTTOM),
+
+    // DRESS
+    MINI("미니 기장", Category.DRESS),
+    MIDI("미디 기장", Category.DRESS),
+    LONG("롱 기장", Category.DRESS);
+
+    private final String name;
+    private final Category parentCategory;
+}
+

--- a/src/main/java/com/example/codionbe/domain/closet/repository/ClothesRepositoryImpl.java
+++ b/src/main/java/com/example/codionbe/domain/closet/repository/ClothesRepositoryImpl.java
@@ -1,14 +1,20 @@
 package com.example.codionbe.domain.closet.repository;
 
 import com.example.codionbe.domain.closet.dto.request.ClothesFilterRequest;
+import com.example.codionbe.domain.closet.entity.Category;
 import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.entity.QClothes;
+import com.example.codionbe.domain.closet.entity.SubCategory;
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Arrays;
 import java.util.List;
+
+import static com.example.codionbe.domain.closet.entity.QClothes.clothes;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,6 +30,10 @@ public class ClothesRepositoryImpl implements com.example.codionbe.domain.closet
 
         builder.and(clothes.userId.eq(userId));
         builder.and(clothes.isDeleted.isFalse());
+
+        if (c.getCategory() != null) {
+            builder.and(eqCategory(c.getCategory()));
+        }
 
         if (c.getPersonalColor() != null)
             builder.and(clothes.personalColor.eq(c.getPersonalColor()));
@@ -51,5 +61,14 @@ public class ClothesRepositoryImpl implements com.example.codionbe.domain.closet
                 .where(builder)
                 .orderBy(clothes.wearCount.desc())
                 .fetch();
+    }
+
+    private BooleanExpression eqCategory(Category category) {
+        return category != null ? clothes.subCategory.stringValue().in(
+                Arrays.stream(SubCategory.values())
+                        .filter(sc -> sc.getParentCategory() == category)
+                        .map(Enum::name)
+                        .toList()
+        ) : null;
     }
 }

--- a/src/main/java/com/example/codionbe/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/example/codionbe/domain/closet/service/ClosetService.java
@@ -147,7 +147,7 @@ public class ClosetService {
         try {
             subCategory = SubCategory.valueOf(subCategoryStr);
         } catch (IllegalArgumentException e) {
-            subCategory = SubCategory.TSHIRT; // 기본값 설정
+            subCategory = SubCategory.SHORT_SLEEVE; // 기본값 설정
         }
 
         PersonalColor personalColor;

--- a/src/main/java/com/example/codionbe/domain/closet/service/ClosetService.java
+++ b/src/main/java/com/example/codionbe/domain/closet/service/ClosetService.java
@@ -9,6 +9,7 @@ import com.example.codionbe.domain.closet.entity.Category;
 import com.example.codionbe.domain.closet.entity.Clothes;
 import com.example.codionbe.domain.closet.dto.request.RegisterClothesRequest;
 import com.example.codionbe.domain.closet.entity.PersonalColor;
+import com.example.codionbe.domain.closet.entity.SubCategory;
 import com.example.codionbe.domain.closet.exception.ClosetErrorCode;
 import com.example.codionbe.domain.closet.repository.ClothesRepository;
 import com.example.codionbe.global.common.exception.CustomException;
@@ -16,7 +17,6 @@ import com.example.codionbe.global.s3.S3Uploader;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -98,7 +98,7 @@ public class ClosetService {
         Clothes clothes = Clothes.builder()
                 .userId(userId)
                 .name(request.getName())
-                .category(request.getCategory())
+                .subCategory(SubCategory.valueOf(request.getSubCategory()))
                 .personalColor(request.getPersonalColor())
                 .color(request.getColor())
                 .suitableForRain(request.isSuitableForRain())
@@ -137,7 +137,7 @@ public class ClosetService {
         // 나머지 정보 수정
         clothes.updateInfo(
                 request.getName(),
-                request.getCategory(),
+                request.getSubCategory(),
                 request.getPersonalColor(),
                 request.getColor(),
                 request.isSuitableForRain(),


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #57 

## 🔑 Key Changes

1. 내용
    - Clothes 엔티티에 대/소분류 필드 추가
    - 필터링 조건 수정 (QueryDSL 등)
    - Swagger 문서 수정

## 📸 Screenshot
